### PR TITLE
Prevent clash  caused by addition of -t to underlying options

### DIFF
--- a/awsfabrictasks/main.py
+++ b/awsfabrictasks/main.py
@@ -56,7 +56,7 @@ def awsfab():
                 )
             )
     state.env_options.append(
-            make_option('-T', '--ec2tags',
+            make_option('-G', '--ec2tags',
                 default='',
                 help=('Comma-separated list of tag=value pairs.')
                 )


### PR DESCRIPTION
Fabric has added -T, so options library raises an options exception.

Simple fix -> -G
