### PR TITLE
Tiny change in api.py docstring

### DIFF
--- a/awsfabrictasks/ec2/api.py
+++ b/awsfabrictasks/ec2/api.py
@@ -454,7 +454,7 @@ class Ec2LaunchInstance(object):
         - Use :meth:`Ec2LaunchInstance.wait_for_running_state_many` to wait for all instances to launch.
         - Do something with the running instances.
 
-    Example of launching many instances:
+    Example of launching many instances::
 
         a = Ec2LaunchInstance(extra_tags={'Name': 'a'})
         b = Ec2LaunchInstance(extra_tags={'Name': 'b'})


### PR DESCRIPTION
Use double double colon to format example as source code
