### PR TITLE
Update api.py

### DIFF
--- a/awsfabrictasks/ec2/api.py
+++ b/awsfabrictasks/ec2/api.py
@@ -256,7 +256,10 @@ class Ec2InstanceWrapper(object):
             the region.
         :return: A :class:`Ec2InstanceWrapper` contaning the requested instance.
         """
-        region, name = parse_instancename(instancename_with_optional_region)
+        try:
+            region, name = parse_instancename(instancename_with_optional_region)
+        except TypeError:
+            raise TypeError("Did you supply an argument to the ec2instance decorator?")
         connection = connect_to_region(region_name=region, **awsfab_settings.AUTH)
         if not connection:
             raise Ec2RegionConnectionError(region)


### PR DESCRIPTION
I spent a while figuring out what I did wrong when I didn't pass in an argument to the decorator. It's obvious in hindsight, but still. The error message I've written is a bit casual; I didn't put a lot of thought into what you might want to write.
- Catch error caused by forgetting the argument on the ec2instance decorator, and give the user a hint.
