### PR TITLE
Fix incompatibility with fabric 1.9.0+

### DIFF
--- a/awsfabrictasks/main.py
+++ b/awsfabrictasks/main.py
@@ -11,7 +11,7 @@ def _splitnames(names):
         return []
 
 def get_hosts_supporting_aws(self, arg_hosts, arg_roles, arg_exclude_hosts, env=None):
-    hosts = tasks.Task.get_hosts(self, arg_hosts, arg_roles, arg_exclude_hosts, env)
+    hosts, roles = tasks.Task.get_hosts_and_effective_roles(self, arg_hosts, arg_roles, arg_exclude_hosts, env)
 
     ids = _splitnames(env.ec2ids)
     for instanceid in ids:
@@ -34,11 +34,11 @@ def get_hosts_supporting_aws(self, arg_hosts, arg_roles, arg_exclude_hosts, env=
             instance.add_instance_to_env()
             hosts.append(instance.get_ssh_uri())
 
-    return hosts
+    return (hosts, roles)
 
 
 def monkey_patch_get_hosts():
-    tasks.WrappedCallableTask.get_hosts = get_hosts_supporting_aws
+    tasks.WrappedCallableTask.get_hosts_and_effective_roles = get_hosts_supporting_aws
 
 def awsfab():
     monkey_patch_get_hosts()


### PR DESCRIPTION
A change contributed by the commit  fabric/fabric@0410f2228788ced3d25130c97e2dac69789f88b2 changes the name `get_hosts` to `get_hosts_and_effective_roles` and returns a tuple instead of a list.
